### PR TITLE
Update to Bevy 0.14.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,17 @@ readme = "Readme.md"
 keywords = ["bevy"]
 categories = ["game-development"]
 repository = "https://github.com/nicopap/bevy-scene-hook"
-version = "10.0.0"
+version = "11.0.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.14.0-rc.3", default-features = false, features = [
+bevy = { version = "0.14.0", default-features = false, features = [
   "bevy_scene",
   "bevy_asset",
 ] }
 
 [dev-dependencies]
-bevy = { version = "0.14.0-rc.3", default-features = true }
+bevy = { version = "0.14.0", default-features = true }
 
 [package.metadata.release]
 pre-release-replacements = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,13 +11,16 @@ version = "10.0.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.13", default-features = false, features = [ "bevy_scene", "bevy_asset" ] }
+bevy = { version = "0.14.0-rc.3", default-features = false, features = [
+  "bevy_scene",
+  "bevy_asset",
+] }
 
 [dev-dependencies]
-bevy = { version = "0.13", default-features = true }
+bevy = { version = "0.14.0-rc.3", default-features = true }
 
 [package.metadata.release]
 pre-release-replacements = [
-  {search="\\| 0.13 \\| [0-9.]* \\|",replace="| 0.13 | {{version}} |",file="Readme.md"},
-  {search="bevy-scene-hook = \"[0-9.]*\"",replace="bevy-scene-hook = \"{{version}}\"",file="Readme.md"},
+  { search = "\\| 0.13 \\| [0-9.]* \\|", replace = "| 0.13 | {{version}} |", file = "Readme.md" },
+  { search = "bevy-scene-hook = \"[0-9.]*\"", replace = "bevy-scene-hook = \"{{version}}\"", file = "Readme.md" },
 ]

--- a/Readme.md
+++ b/Readme.md
@@ -16,7 +16,7 @@ copy/pasting the code as a module, you can get it from [crates.io].
 1. Add the crate to your dependencies
 ```toml
 [dependencies]
-bevy-scene-hook = "10.0.0"
+bevy-scene-hook = "11.0.0"
 ```
 2. Add the plugin
 ```rust,ignore
@@ -182,11 +182,13 @@ Those extra items are all defined in `lib.rs`.
 * `10.0.0`: **Breaking**: bump bevy version to `0.13`.
   * Remove the `file_path` `reload::Hook` field in favor of the `Handle::path` method.
   * Add an example and test the Readme.
+* `11.0.0`: **Breaking**: bump bevy version to `0.14`.
 
 ### Version matrix
 
 | bevy | latest supporting version      |
 |------|-------|
+| 0.14 | 11.0.0 |
 | 0.13 | 10.0.0 |
 | 0.12 | 9.0.0 |
 | 0.11 | 8.0.0 |

--- a/examples/simple_scene.rs
+++ b/examples/simple_scene.rs
@@ -5,7 +5,7 @@
 //! a color name.
 use std::f32::consts::TAU;
 
-use bevy::prelude::*;
+use bevy::{color::palettes::css, prelude::*};
 use bevy_scene_hook::{reload, HookPlugin, HookedSceneBundle, SceneHook};
 
 // You can open this file in Blender and modify it, or just open it with a
@@ -52,10 +52,10 @@ fn show_gizmos(mut gizmos: Gizmos, to_show: Query<(&GlobalTransform, &ShowGizmo)
                 gizmos.cuboid(cuboid, to_show.color);
             }
             Shape::Cone => {
-                gizmos.primitive_3d(cone, pos, rot, to_show.color);
+                gizmos.primitive_3d(&cone, pos, rot, to_show.color);
             }
             Shape::Cylinder => {
-                gizmos.primitive_3d(cylinder, pos, rot, to_show.color);
+                gizmos.primitive_3d(&cylinder, pos, rot, to_show.color);
             }
         }
     }
@@ -99,10 +99,10 @@ fn load_scenes(mut cmds: Commands, server: Res<AssetServer>) {
             // parse it and add different thing based on the name. For example,
             // you could convert the name into a color instead of hardcoding the color.
             match entity.get().map(Name::as_str) {
-                Some("yellow") => cmds.insert(show_gizmo(Color::YELLOW, Shape::Sphere)),
-                Some("red") => cmds.insert(show_gizmo(Color::RED, Shape::Cone)),
-                Some("green") => cmds.insert(show_gizmo(Color::GREEN, Shape::Cone)),
-                Some("blue") => cmds.insert(show_gizmo(Color::BLUE, Shape::Sphere)),
+                Some("yellow") => cmds.insert(show_gizmo(css::YELLOW.into(), Shape::Sphere)),
+                Some("red") => cmds.insert(show_gizmo(css::RED.into(), Shape::Cone)),
+                Some("green") => cmds.insert(show_gizmo(css::GREEN.into(), Shape::Cone)),
+                Some("blue") => cmds.insert(show_gizmo(css::BLUE.into(), Shape::Sphere)),
                 Some("Cube") => cmds.insert(Cube(-0.025)),
                 _ => cmds,
             };
@@ -119,10 +119,10 @@ fn load_scenes(mut cmds: Commands, server: Res<AssetServer>) {
         },
         reload: reload::Hook::new(move |entity, cmds, _world, _root| {
             match entity.get().map(Name::as_str) {
-                Some("yellow") => cmds.insert(show_gizmo(Color::YELLOW, Shape::Cube)),
-                Some("red") => cmds.insert(show_gizmo(Color::RED, Shape::Cylinder)),
-                Some("green") => cmds.insert(show_gizmo(Color::GREEN, Shape::Cylinder)),
-                Some("blue") => cmds.insert(show_gizmo(Color::BLUE, Shape::Cube)),
+                Some("yellow") => cmds.insert(show_gizmo(css::YELLOW.into(), Shape::Cube)),
+                Some("red") => cmds.insert(show_gizmo(css::RED.into(), Shape::Cylinder)),
+                Some("green") => cmds.insert(show_gizmo(css::GREEN.into(), Shape::Cylinder)),
+                Some("blue") => cmds.insert(show_gizmo(css::BLUE.into(), Shape::Cube)),
                 Some("Cube") => cmds.insert(Cube(0.05)),
                 _ => cmds,
             };
@@ -146,7 +146,7 @@ fn reload_scene(
             let descendants = children.iter_descendants(entity);
             let mut iter = trans.iter_many_mut(descendants);
             while let Some((mut giz, mut trans)) = iter.fetch_next() {
-                let color = giz.color.hsl_to_vec3();
+                let color = giz.color.to_srgba().to_vec3();
                 giz.color = Color::hsl((color.x + 10.) % 360.0, color.y, color.z);
 
                 trans.rotation *= Quat::from_rotation_x(TAU / 11.);

--- a/src/reload.rs
+++ b/src/reload.rs
@@ -1,6 +1,7 @@
 //! Defines reloading [`Hook`]s and supporting system.
 
-use bevy::ecs::system::{Command, EntityCommands};
+use bevy::ecs::system::EntityCommands;
+use bevy::ecs::world::Command;
 use bevy::prelude::{
     AssetServer, Bundle, Commands, Component, DespawnRecursiveExt, Entity, EntityRef, Handle,
     IntoSystemConfigs, Plugin as BevyPlugin, Query, Reflect, Res, Scene,


### PR DESCRIPTION
Minor changes for updating to 0.14.0

I'm not sure of the exact process but I think this is fine to stay as a PR until they actually release 0.14 and then I can change the exact versions to be ^0.14.0? Not sure